### PR TITLE
Some file doesn't have the modified_time attribute.

### DIFF
--- a/django_downloadview/views.py
+++ b/django_downloadview/views.py
@@ -48,7 +48,8 @@ class DownloadMixin(object):
         file_instance = self.get_file()
         if_modified_since = self.request.META.get('HTTP_IF_MODIFIED_SINCE',
                                                   None)
-        if if_modified_since is not None:
+        if if_modified_since is not None and \
+                hasattr(file_instance, 'modified_time'):
             modification_time = file_instance.modified_time
             size = file_instance.size
             if not was_modified_since(if_modified_since, modification_time,


### PR DESCRIPTION
The problem is that in that case we cannot use the cache maybe we should add a warning to let the developer knows that he needs to implements the modified_time on his file object.
