### PR TITLE
PathDownloadView opens files in binary mode by default.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@ future releases, check `milestones`_ and :doc:`/about/vision`.
 Big refactoring around middleware configuration, API readability and
 documentation.
 
+- Bugfix #57 - ``PathDownloadView`` opens files in binary mode (was text mode).
+
 - Bugfix #44 - Introduced ``django_downloadview.File``, which patches
   ``django.core.files.base.File.__iter__()`` implementation.
   See https://code.djangoproject.com/ticket/21321

--- a/django_downloadview/views/path.py
+++ b/django_downloadview/views/path.py
@@ -30,4 +30,4 @@ class PathDownloadView(BaseDownloadView):
 
     def get_file(self):
         """Use path to return wrapper around file to serve."""
-        return File(open(self.get_path()))
+        return File(open(self.get_path(), 'rb'))


### PR DESCRIPTION
Was text mode.
Refs #57
