### PR TITLE
Added ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ install:
   - pip install -q tox-travis
 script:
   - tox
+arch:
+  - amd64
+  - ppc64le
+


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-downloadview/builds/186493041

Please have a look.

Regards,
Kishor Kunal Raj