### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,16 @@
 language: python
 dist: bionic
 python:
-- 3.6
-- 3.7
-- 3.8
-- 3.9-dev
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9-dev
 install:
-- pip install tox tox-travis
+  - pip install tox
+  - pip install -q tox-travis
 script:
-- tox -v
-jobs:
-  fast_finish: true
-  include:
-    - stage: deploy
-      env:
-      python: 3.7
-      script: skip
-      deploy:
-        provider: pypi
-        user: jazzband
-        server: https://jazzband.co/projects/django-downloadview/upload
-        distributions: sdist bdist_wheel
-        password:
-          secure: TYFfz5OkSH0YwTKh0lc0PbddcuZh5oL2H1AVIXHs2dODQ46PNgLYgDRe9k9PItAenxm7QCnGRONJo2o1GNuiCcAOWK84jbrmufHZ5EeKTOVtssyrffSA/Oxfs5mFJ/Kgy3o8FC1hGRKXrXFN3bvedmVHERGQimQESPxHQ9sPWhc=
-        skip_existing: true
-        skip_cleanup: true
-        on:
-          tags: true
-          repo: jazzband/django-downloadview
-          python: 3.7
-after_success:
-  - pip install coveralls
-  - coveralls
+  - tox
+arch:
+  - amd64
+  - ppc64le
+


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the branch and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/django-downloadview/builds/188862781

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Also to be noted that it will run tests on both the architectures  i.e. amd64(intel) as well as on ppc64le (Linux on Power)

Please have a look.

Regards,
Kishor Kunal Raj