### PR TITLE
Require supported Django version 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     zip_safe=False,
     install_requires=[
         # BEGIN requirements
-        "Django>=1.11",
+        "Django>=2.2",
         "requests",
         "setuptools",
         # END requirements


### PR DESCRIPTION
Django 2.2 is the oldest supported version of Django, and oldest tested by the project.