### PR TITLE
Fix doc code include in ObjectDownloadView

### DIFF
--- a/docs/views/object.txt
+++ b/docs/views/object.txt
@@ -90,7 +90,7 @@ Then you can configure the :attr:`ObjectDownloadView.basename_field` option:
 
 .. literalinclude:: /../demo/demoproject/object/views.py
    :language: python
-   :lines: 1-5, 16-18
+   :lines: 1-4, 13-17
 
 .. note::
 

--- a/docs/views/object.txt
+++ b/docs/views/object.txt
@@ -38,7 +38,7 @@ Setup a view to stream the ``file`` attribute:
 
 .. literalinclude:: /../demo/demoproject/object/urls.py
    :language: python
-   :lines: 1-7, 8-11, 20
+   :lines: 1-7, 8-11, 27
 
 
 ************

--- a/docs/views/object.txt
+++ b/docs/views/object.txt
@@ -30,7 +30,7 @@ Setup a view to stream the ``file`` attribute:
 
 .. literalinclude:: /../demo/demoproject/object/views.py
    :language: python
-   :lines: 1-5, 7
+   :lines: 1-6
 
 :class:`~django_downloadview.views.object.ObjectDownloadView` inherits from
 :class:`~django.views.generic.detail.BaseDetailView`, i.e. it expects either

--- a/docs/views/object.txt
+++ b/docs/views/object.txt
@@ -69,7 +69,7 @@ Then here is the code to serve "another_file" instead of the default "file":
 
 .. literalinclude:: /../demo/demoproject/object/views.py
    :language: python
-   :lines: 1-5, 10-12
+   :lines: 1-4, 8-11
 
 
 **********************************


### PR DESCRIPTION
Fix rendering in docs that misses the final line in the necessary example code below:

<img width="700" alt="Screen Shot 2021-01-21 at 12 44 21 PM" src="https://user-images.githubusercontent.com/10340167/105390630-3fbf3280-5be7-11eb-9609-b8fe2d9e2cb6.png">

As well as three others on that page.