### PR TITLE
Replace mention of deprecated NGINX_DOWNLOAD_MIDDLEWARE_SOURCE_DIR

### DIFF
--- a/docs/optimizations/nginx.txt
+++ b/docs/optimizations/nginx.txt
@@ -183,7 +183,7 @@ Add ``charset utf-8;`` in your nginx configuration file.
 ``open() "path/to/something" failed (2: No such file or directory)``
 ====================================================================
 
-Check your ``settings.NGINX_DOWNLOAD_MIDDLEWARE_MEDIA_ROOT`` in Django
+Check your ``settings.NGINX_DOWNLOAD_MIDDLEWARE_SOURCE_DIR`` in Django
 configuration VS ``alias`` in nginx configuration: in a standard configuration,
 they should be equal.
 


### PR DESCRIPTION
`NGINX_DOWNLOAD_MIDDLEWARE_MEDIA_ROOT` is deprecated in favor of `NGINX_DOWNLOAD_MIDDLEWARE_SOURCE_DIR`

https://github.com/jazzband/django-downloadview/blob/563b2a4f7b354cb930aa7067e6e1341dbb34f5e7/django_downloadview/nginx/middlewares.py#L120-L121