### PR TITLE
Remove duplicate trove classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     long_description_content_type='text/x-rst',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
-        "Framework :: Django",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
#182 accidently added a duplicate `Django` trove classifier