### PR TITLE
Update compatibility for Django 4.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,19 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', 'main']
+        exclude:
+        # Django prior to 3.2 does not support Python 3.10
+        - django-version: '2.2'
+          python-version: '3.10'
+        - django-version: '3.1'
+          python-version: '3.10'
+        # Django after 3.2 drop support for Python prior to 3.8
+        - django-version: 'main'
+          python-version: '3.6'
+        - django-version: 'main'
+          python-version: '3.7'
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 5
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', '4.0', 'main']

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,20 @@ jobs:
       max-parallel: 5
       matrix:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2', 'main']
+        django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
         exclude:
         # Django prior to 3.2 does not support Python 3.10
         - django-version: '2.2'
           python-version: '3.10'
         - django-version: '3.1'
           python-version: '3.10'
-        # Django after 3.2 drop support for Python prior to 3.8
+        # Django after 3.2 dropped support for Python prior to 3.8
+        - django-version: '4.0'
+          python-version: '3.6'
         - django-version: 'main'
           python-version: '3.6'
+        - django-version: '4.0'
+          python-version: '3.7'
         - django-version: 'main'
           python-version: '3.7'
 

--- a/demo/demoproject/settings.py
+++ b/demo/demoproject/settings.py
@@ -53,8 +53,6 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    # Stuff that must be at the end.
-    "django_nose",
 )
 
 
@@ -111,15 +109,6 @@ DOWNLOADVIEW_RULES += [
 
 # Test/development settings.
 DEBUG = True
-TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
-NOSE_ARGS = [
-    "--verbosity=2",
-    "--no-path-adjustment",
-    "--nocapture",
-    "--all-modules",
-    "--with-coverage",
-    "--with-doctest",
-]
 
 
 TEMPLATES = [

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=["demoproject"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=["django-downloadview", "django-nose"],
+    install_requires=["django-downloadview", "pytest-django"],
     entry_points={"console_scripts": ["demo = demoproject.manage:main"]},
 )

--- a/django_downloadview/io.py
+++ b/django_downloadview/io.py
@@ -1,7 +1,7 @@
 """Low-level IO operations, for use with file wrappers."""
 import io
 
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 
 class TextIteratorIO(io.TextIOBase):
@@ -32,7 +32,7 @@ class TextIteratorIO(io.TextIOBase):
                 break
             else:
                 # Make sure we handle text.
-                self._left = force_text(self._left)
+                self._left = force_str(self._left)
         ret = self._left[:n]
         self._left = self._left[len(ret) :]
         return ret

--- a/django_downloadview/middlewares.py
+++ b/django_downloadview/middlewares.py
@@ -4,7 +4,7 @@ Download middlewares capture :py:class:`django_downloadview.DownloadResponse`
 responses and may replace them with optimized download responses.
 
 """
-import collections
+import collections.abc
 import copy
 import os
 
@@ -160,7 +160,7 @@ class SmartDownloadMiddleware(BaseDownloadMiddleware):
         for key, options in enumerate(options_list):
             args = []
             kwargs = {}
-            if isinstance(options, collections.Mapping):  # Using kwargs.
+            if isinstance(options, collections.abc.Mapping):  # Using kwargs.
                 kwargs = options
             else:
                 args = options

--- a/django_downloadview/middlewares.py
+++ b/django_downloadview/middlewares.py
@@ -14,14 +14,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django_downloadview.response import DownloadResponse
 from django_downloadview.utils import import_member
 
-try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-
-    class MiddlewareMixin(object):
-        def __init__(self, get_response=None):
-            super(MiddlewareMixin, self).__init__()
-
 
 #: Sentinel value to detect whether configuration is to be loaded from Django
 #: settings or not.
@@ -38,12 +30,18 @@ def is_download_response(response):
     return isinstance(response, DownloadResponse)
 
 
-class BaseDownloadMiddleware(MiddlewareMixin):
+class BaseDownloadMiddleware:
     """Base (abstract) Django middleware that handles download responses.
 
     Subclasses **must** implement :py:meth:`process_download_response` method.
 
     """
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return self.process_response(request, response)
 
     def is_download_response(self, response):
         """Return True if ``response`` can be considered as a file download.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'Framework :: Django :: 2.2',
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
+        'Framework :: Django :: 4.0',
     ],
     keywords=" ".join(
         [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,39,310}-dj{22,31,32}
-    py{38,39,310}-djmain
+    py{38,39,310}-dj{40,main}
     lint
     sphinx
     readme
@@ -19,6 +19,7 @@ DJANGO =
     2.2: dj22
     3.1: dj31
     3.2: dj32
+    4.0: dj40
     main: djmain
 
 [testenv]
@@ -27,6 +28,7 @@ deps =
     dj22: Django>=2.2,<3.0
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
+    dj40: Django>=4.0,<4.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,16 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     djmain: https://github.com/django/django/archive/main.tar.gz
-    nose
+    pytest
+    pytest-cov
 commands =
     pip install -e .
     pip install -e demo
-    python -Wd {envbindir}/demo test --cover-package=django_downloadview --cover-package=demoproject --cover-xml {posargs: tests demoproject}
+    # doctests
+    pytest --cov=django_downloadview --cov=demoproject {posargs}
+    # all other test cases
+    coverage run --append {envbindir}/demo test {posargs: tests demoproject}
+    coverage xml
     pip freeze
 ignore_outcome =
     djmain: True
@@ -65,3 +70,10 @@ commands =
 [flake8]
 max-line-length = 88
 ignore = E203, W503
+
+[coverage:run]
+source = django_downloadview,demo
+
+[pytest]
+DJANGO_SETTINGS_MODULE = demoproject.settings
+addopts = --doctest-modules --ignore=docs/

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,31,32}
-    py{38,39}-djmain
+    py{36,37,38,39,310}-dj{22,31,32}
+    py{38,39,310}-djmain
     lint
     sphinx
     readme
@@ -12,6 +12,7 @@ python =
     3.7: py37
     3.8: py38, lint, sphinx, readme
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
The only documented compatibility change is removing use of `force_text` (which was
deprecated in Django 3.0) in favor of `force_str` (which has existed
since before Django 1.11). There are also some changes in middleware because Django's MiddlewareMixin started requiring a `get_response` argument to the constructor.

Fixes #187.