### PR TITLE
Support Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,19 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', 'main']
+        exclude:
+        # Django prior to 3.2 does not support Python 3.10
+        - django-version: '2.2'
+          python-version: '3.10'
+        - django-version: '3.1'
+          python-version: '3.10'
+        # Django after 3.2 drop support for Python prior to 3.8
+        - django-version: 'main'
+          python-version: '3.6'
+        - django-version: 'main'
+          python-version: '3.7'
 
     steps:
     - uses: actions/checkout@v2

--- a/demo/demoproject/settings.py
+++ b/demo/demoproject/settings.py
@@ -53,8 +53,6 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    # Stuff that must be at the end.
-    "django_nose",
 )
 
 
@@ -111,15 +109,6 @@ DOWNLOADVIEW_RULES += [
 
 # Test/development settings.
 DEBUG = True
-TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
-NOSE_ARGS = [
-    "--verbosity=2",
-    "--no-path-adjustment",
-    "--nocapture",
-    "--all-modules",
-    "--with-coverage",
-    "--with-doctest",
-]
 
 
 TEMPLATES = [

--- a/demo/setup.py
+++ b/demo/setup.py
@@ -21,6 +21,6 @@ setup(
     packages=["demoproject"],
     include_package_data=True,
     zip_safe=False,
-    install_requires=["django-downloadview", "django-nose"],
+    install_requires=["django-downloadview", "pytest-django"],
     entry_points={"console_scripts": ["demo = demoproject.manage:main"]},
 )

--- a/django_downloadview/middlewares.py
+++ b/django_downloadview/middlewares.py
@@ -4,7 +4,7 @@ Download middlewares capture :py:class:`django_downloadview.DownloadResponse`
 responses and may replace them with optimized download responses.
 
 """
-import collections
+import collections.abc
 import copy
 import os
 
@@ -160,7 +160,7 @@ class SmartDownloadMiddleware(BaseDownloadMiddleware):
         for key, options in enumerate(options_list):
             args = []
             kwargs = {}
-            if isinstance(options, collections.Mapping):  # Using kwargs.
+            if isinstance(options, collections.abc.Mapping):  # Using kwargs.
                 kwargs = options
             else:
                 args = options

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,16 @@ deps =
     dj31: Django>=3.1,<3.2
     dj32: Django>=3.2,<3.3
     djmain: https://github.com/django/django/archive/main.tar.gz
-    nose
+    pytest
+    pytest-cov
 commands =
     pip install -e .
     pip install -e demo
-    python -Wd {envbindir}/demo test --cover-package=django_downloadview --cover-package=demoproject --cover-xml {posargs: tests demoproject}
+    # doctests
+    pytest --cov=django_downloadview --cov=demoproject {posargs}
+    # all other test cases
+    coverage run --append {envbindir}/demo test {posargs: tests demoproject}
+    coverage xml
     pip freeze
 ignore_outcome =
     djmain: True
@@ -65,3 +70,10 @@ commands =
 [flake8]
 max-line-length = 88
 ignore = E203, W503
+
+[coverage:run]
+source = django_downloadview,demo
+
+[pytest]
+DJANGO_SETTINGS_MODULE = demoproject.settings
+addopts = --doctest-modules --ignore=docs/

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{36,37,38,39}-dj{22,31,32}
-    py{38,39}-djmain
+    py{36,37,38,39,310}-dj{22,31,32}
+    py{38,39,310}-djmain
     lint
     sphinx
     readme
@@ -12,6 +12,7 @@ python =
     3.7: py37
     3.8: py38, lint, sphinx, readme
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 DJANGO =


### PR DESCRIPTION
nosetests is no longer supported upstream and broken on Python 3.10, so this requires migrating to something else, where I've chosen pytest to run doctests and manually using `coverage` otherwise. One ABC used from `collections` moved to `collections.abc` in Python 3.2, which can safely be updated.