### PR TITLE
Removed passing unused size parameter to was_modified_since().

### DIFF
--- a/django_downloadview/views/base.py
+++ b/django_downloadview/views/base.py
@@ -102,9 +102,9 @@ class DownloadMixin(object):
         Else, fallbacks to default implementation, which uses
         :py:func:`django.views.static.was_modified_since`.
 
-        Django's ``was_modified_since`` function needs a datetime and a size.
-        It is passed ``modified_time`` and ``size`` attributes from file
-        wrapper. If file wrapper does not support these attributes
+        Django's ``was_modified_since`` function needs a datetime.
+        It is passed the ``modified_time`` attribute from file
+        wrapper. If file wrapper does not support this attribute
         (``AttributeError`` or ``NotImplementedError`` is raised), then
         the file is considered as modified and ``True`` is returned.
 
@@ -116,12 +116,11 @@ class DownloadMixin(object):
                 modification_time = calendar.timegm(
                     file_instance.modified_time.utctimetuple()
                 )
-                size = file_instance.size
             except (AttributeError, NotImplementedError) as e:
                 print("!=======!", e)
                 return True
             else:
-                return was_modified_since(since, modification_time, size)
+                return was_modified_since(since, modification_time)
 
     def not_modified_response(self, *response_args, **response_kwargs):
         """Return :class:`django.http.HttpResponseNotModified` instance."""

--- a/tests/views.py
+++ b/tests/views.py
@@ -85,13 +85,12 @@ class DownloadMixinTestCase(unittest.TestCase):
         When calling file wrapper's ``was_modified_since()`` raises
         ``NotImplementedError`` or ``AttributeError``,
         :meth:`django_downloadview.views.base.DownloadMixin.was_modified_since`
-        tries to pass file wrapper's ``size`` and ``modified_time`` to
+        tries to pass file wrapper's ``modified_time`` to
         :func:`django.views.static import was_modified_since`.
 
         """
         file_wrapper = mock.Mock()
         file_wrapper.was_modified_since = mock.Mock(side_effect=AttributeError)
-        file_wrapper.size = mock.sentinel.size
         file_wrapper.modified_time = datetime.now()
         was_modified_since_mock = mock.Mock(return_value=mock.sentinel.was_modified)
         mixin = views.DownloadMixin()
@@ -106,7 +105,6 @@ class DownloadMixinTestCase(unittest.TestCase):
         was_modified_since_mock.assert_called_once_with(
             mock.sentinel.since,
             calendar.timegm(file_wrapper.modified_time.utctimetuple()),
-            mock.sentinel.size,
         )
 
     def test_was_modified_since_fallback(self):
@@ -117,7 +115,7 @@ class DownloadMixinTestCase(unittest.TestCase):
         * calling file wrapper's ``was_modified_since()`` raises
           ``NotImplementedError`` or ``AttributeError``;
 
-        * and accessing ``size`` and ``modified_time`` from file wrapper raises
+        * and accessing ``modified_time`` from file wrapper raises
           ``NotImplementedError`` or ``AttributeError``...
 
         ... then


### PR DESCRIPTION
The size parameter is unused because we pass timestamp and not the If-Modified-Since HTML header. Moreover it's outdated and will be removed in Django 4.1, see:

- https://github.com/django/django/pull/15500