### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
         exclude:
         # Django prior to 3.2 does not support Python 3.10
@@ -18,10 +18,6 @@ jobs:
         - django-version: '3.1'
           python-version: '3.10'
         # Django after 3.2 dropped support for Python prior to 3.8
-        - django-version: '4.0'
-          python-version: '3.6'
-        - django-version: 'main'
-          python-version: '3.6'
         - django-version: '4.0'
           python-version: '3.7'
         - django-version: 'main'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,17 +5,19 @@ This document describes changes between past releases. For information about
 future releases, check `milestones`_ and :doc:`/about/vision`.
 
 
-2.3 (unreleased)
+2.4 (Unreleased)
+----------------
+
+- Drop support for Python 3.6
+
+
+2.3 (2022-01-11)
 ----------------
 
 - Drop Django 3.0 support
 - Add Django 3.2 support
 - Add support for Python 3.10
 - Add support for Django 4.0
-
-2.2 (unreleased)
-----------------
-
 - Remove support for Python 3.5 and Django 1.11
 - Add support for Python 3.9 and Django 3.1
 - Remove old urls syntax and adopt the new one

--- a/INSTALL
+++ b/INSTALL
@@ -12,8 +12,8 @@ Install
 Requirements
 ************
 
-`django-downloadview` has been tested with `Python`_ 3.6, 3.7 and 3.8. Other
-versions may work, but they are not part of the test suite at the moment.
+`django-downloadview` has been tested with `Python`_ 3.7, 3.8, 3.9 and 3.10.
+Other versions may work, but they are not part of the test suite at the moment.
 
 Installing `django-downloadview` will automatically trigger the installation of
 the following requirements:

--- a/demo/README.rst
+++ b/demo/README.rst
@@ -31,7 +31,7 @@ Deploy the demo
 
 System requirements:
 
-* `Python`_ version 3.6+, available as ``python`` command.
+* `Python`_ version 3.7+, available as ``python`` command.
   
   .. note::
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-dj{22,31,32}
+    py{37,38,39,310}-dj{22,31,32}
     py{38,39,310}-dj{40,main}
     lint
     sphinx
@@ -8,7 +8,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.6: py36
     3.7: py37
     3.8: py38, lint, sphinx, readme
     3.9: py39


### PR DESCRIPTION
Python 3.6 is end of life, and has been failing in CI due to upstream packages dropping support for it