### PR TITLE
Enforce minimum Python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ setup(
     ],
     include_package_data=True,
     zip_safe=False,
+    python_requires=">=3.7",
     install_requires=[
         # BEGIN requirements
         "Django>=2.2",


### PR DESCRIPTION
This helps `pip` do version resolution based on the current version of Python running when `django-downloadview` is requested to be installed.

- https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#python-requires