### PR TITLE
Use safer check in RealDownloadMiddleware

### DIFF
--- a/django_downloadview/middlewares.py
+++ b/django_downloadview/middlewares.py
@@ -75,14 +75,10 @@ class RealDownloadMiddleware(BaseDownloadMiddleware):
         whose file attribute have either an URL or a file name.
 
         """
-        if super().is_download_response(response):
-            try:
-                return response.file.url or response.file.name
-            except AttributeError:
-                return False
-            else:
-                return True
-        return False
+        return (
+            super().is_download_response(response)
+            and bool(getattr(response.file, 'url', None) or getattr(response.file, 'name', None))
+        )
 
 
 class DownloadDispatcher:


### PR DESCRIPTION
As pointed in #184 `RealDownloadMiddleware` fails to correctly process a file which has `name` attribute but not `url`, giving a false response.

Also this simplify the whole logic of the `RealDownloadMiddleware.is_download_response` method.