### PR TITLE
Update usage of middleware settings

### DIFF
--- a/django_downloadview/nginx/settings.py
+++ b/django_downloadview/nginx/settings.py
@@ -17,14 +17,7 @@ from django.core.exceptions import ImproperlyConfigured
 deprecated_middleware = "django_downloadview.nginx.XAccelRedirectMiddleware"
 
 
-def get_middlewares():
-    try:
-        return settings.MIDDLEWARE
-    except AttributeError:
-        return settings.MIDDLEWARE_CLASSES
-
-
-if deprecated_middleware in get_middlewares():
+if deprecated_middleware in settings.MIDDLEWARE:
     raise ImproperlyConfigured(
         "{deprecated_middleware} middleware has been renamed as of "
         "django-downloadview version 1.3. You may use "

--- a/docs/django-sendfile.txt
+++ b/docs/django-sendfile.txt
@@ -31,7 +31,7 @@ Here are tips to migrate from `django-sendfile` to `django-downloadview`...
    * setup ``DOWNLOADVIEW_RULES``. It replaces ``SENDFILE_ROOT`` and can do
      more.
    * register ``django_downloadview.SmartDownloadMiddleware`` in
-     ``MIDDLEWARE_CLASSES``.
+     ``MIDDLEWARE``.
 
 4. Change your tests if any. You can no longer use `django-senfile`'s
    ``development`` backend. See :doc:`/testing` for `django-downloadview`'s

--- a/docs/optimizations/apache.txt
+++ b/docs/optimizations/apache.txt
@@ -45,7 +45,7 @@ Setup XSendfile middlewares
 ***************************
 
 Make sure ``django_downloadview.SmartDownloadMiddleware`` is in
-``MIDDLEWARE_CLASSES`` of your `Django` settings.
+``MIDDLEWARE`` of your `Django` settings.
 
 Example:
 
@@ -128,4 +128,4 @@ setup.
 
 .. target-notes::
 
-.. _`Apache mod_xsendfile documentation`: https://tn123.org/mod_xsendfile/ 
+.. _`Apache mod_xsendfile documentation`: https://tn123.org/mod_xsendfile/

--- a/docs/optimizations/lighttpd.txt
+++ b/docs/optimizations/lighttpd.txt
@@ -51,7 +51,7 @@ Setup XSendfile middlewares
 ***************************
 
 Make sure ``django_downloadview.SmartDownloadMiddleware`` is in
-``MIDDLEWARE_CLASSES`` of your `Django` settings.
+``MIDDLEWARE`` of your `Django` settings.
 
 Example:
 

--- a/docs/settings.txt
+++ b/docs/settings.txt
@@ -13,11 +13,11 @@ There is no need to register this application in ``INSTALLED_APPS``.
 
 
 ******************
-MIDDLEWARE_CLASSES
+MIDDLEWARE
 ******************
 
 If you plan to setup :doc:`reverse-proxy optimizations </optimizations/index>`,
-add ``django_downloadview.SmartDownloadMiddleware`` to ``MIDDLEWARE_CLASSES``.
+add ``django_downloadview.SmartDownloadMiddleware`` to ``MIDDLEWARE``.
 It is a response middleware. Move it after middlewares that compute the
 response content such as gzip middleware.
 
@@ -91,7 +91,7 @@ Example:
 See :doc:`/optimizations/index` for a list of available backends (middlewares).
 
 When ``django_downloadview.SmartDownloadMiddleware`` is in your
-``MIDDLEWARE_CLASSES``, this setting must be explicitely configured (no default
+``MIDDLEWARE``, this setting must be explicitely configured (no default
 value). Else, you can ignore this setting.
 
 
@@ -119,5 +119,5 @@ See :doc:`/optimizations/index` for details about builtin backends
 (middlewares) and their options.
 
 When ``django_downloadview.SmartDownloadMiddleware`` is in your
-``MIDDLEWARE_CLASSES``, this setting must be explicitely configured (no default
+``MIDDLEWARE``, this setting must be explicitely configured (no default
 value). Else, you can ignore this setting.

--- a/tests/api.py
+++ b/tests/api.py
@@ -100,7 +100,6 @@ class DeprecatedAPITestCase(django.test.SimpleTestCase):
     def test_nginx_x_accel_redirect_middleware(self):
         "XAccelRedirectMiddleware in settings triggers ImproperlyConfigured."
         with override_settings(
-            MIDDLEWARE_CLASSES=["django_downloadview.nginx.XAccelRedirectMiddleware"],
             MIDDLEWARE=["django_downloadview.nginx.XAccelRedirectMiddleware"],
         ):
             with self.assertRaises(ImproperlyConfigured):


### PR DESCRIPTION
Since this library is tested only against `django>=2.2`, there are no reason to keep using the old-style `MIDDLEWARE_CLASSES` settings whose support was [removed in django 2.0](https://docs.djangoproject.com/en/stable/releases/2.0/#features-removed-in-2-0).