### PR TITLE
Replace use of pkg_resources (setuptools)

### DIFF
--- a/django_downloadview/__init__.py
+++ b/django_downloadview/__init__.py
@@ -1,7 +1,7 @@
 """Serve files with Django and reverse proxies."""
 from django_downloadview.api import *  # NoQA
 
-import pkg_resources
+import importlib.metadata
 
 #: Module version, as defined in PEP-0396.
-__version__ = pkg_resources.get_distribution(__package__.replace("-", "_")).version
+__version__ = importlib.metadata.version(__package__.replace("-", "_"))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,8 @@
 """django-downloadview documentation build configuration file."""
 import os
 import re
-from pkg_resources import get_distribution
+
+import importlib.metadata
 
 # Minimal Django settings. Required to use sphinx.ext.autodoc, because
 # django-downloadview depends on Django...
@@ -48,7 +49,7 @@ author_slug = re.sub(r"([\w_.-]+)", "-", author)
 # built documents.
 
 # The full version, including alpha/beta/rc tags.
-release = get_distribution("django-downloadview").version
+release = importlib.metadata.version("django-downloadview")
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
     install_requires=[
         # BEGIN requirements
         "Django>=4.2",
-        "setuptools",
         "requests",
         # END requirements
     ],

--- a/tests/packaging.py
+++ b/tests/packaging.py
@@ -24,22 +24,14 @@ class VersionTestCase(unittest.TestCase):
             self.fail("django_downloadview package has no __version__.")
 
     def test_version_match(self):
-        """django_downloadview.__version__ matches pkg_resources info."""
-        try:
-            import pkg_resources
-        except ImportError:
-            self.fail(
-                "Cannot import pkg_resources module. It is part of "
-                "setuptools, which is a dependency of "
-                "django_downloadview."
-            )
-        distribution = pkg_resources.get_distribution("django-downloadview")
+        """django_downloadview.__version__ matches importlib metadata."""
+        distribution = importlib.metadata.distribution("django-downloadview")
         installed_version = distribution.version
         self.assertEqual(
             installed_version,
             self.get_version(),
             "Version mismatch: django_downloadview.__version__ "
-            'is "%s" whereas pkg_resources tells "%s". '
+            'is "%s" whereas importlib.metadata tells "%s". '
             "You may need to run ``make develop`` to update the "
             "installed version in development environment."
             % (self.get_version(), installed_version),


### PR DESCRIPTION
Since Python 3.12, setuptools isn't included with Python
and importlib is the recommended replacement, available
since Python 3.8. Since #210 dropped support for older versions
of Python, we can just use `importlib.metadata`.

Fixes #208.