### PR TITLE
Upgrade support matrix to maintained versions of Django

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,19 +9,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
-        django-version: ['2.2', '3.1', '3.2', '4.0', 'main']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        django-version: ['4.2', '5.0', 'main']
         exclude:
-        # Django prior to 3.2 does not support Python 3.10
-        - django-version: '2.2'
-          python-version: '3.10'
-        - django-version: '3.1'
-          python-version: '3.10'
-        # Django after 3.2 dropped support for Python prior to 3.8
-        - django-version: '4.0'
-          python-version: '3.7'
+        # Django 5.0 dropped support for Python <3.10
+        - django-version: '5.0'
+          python-version: '3.8'
+        - django-version: '5.0'
+          python-version: '3.9'
         - django-version: 'main'
-          python-version: '3.7'
+          python-version: '3.8'
+        - django-version: 'main'
+          python-version: '3.9'
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,14 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         'Framework :: Django',
-        'Framework :: Django :: 2.2',
-        'Framework :: Django :: 3.1',
-        'Framework :: Django :: 3.2',
-        'Framework :: Django :: 4.0',
+        'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
     ],
     keywords=" ".join(
         [
@@ -53,10 +52,11 @@ setup(
     ],
     include_package_data=True,
     zip_safe=False,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         # BEGIN requirements
-        "Django>=2.2",
+        "Django>=4.2",
+        "setuptools",
         "requests",
         # END requirements
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,33 +1,30 @@
 [tox]
 envlist =
-    py{37,38,39,310}-dj{22,31,32}
-    py{38,39,310}-dj{40,main}
+    py{38,39,310,311,312}-dj42
+    py{310,311,312}-dj{50,main}
     lint
     sphinx
     readme
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38, lint, sphinx, readme
     3.9: py39
     3.10: py310
+    3.11: py311
+    3.12: py312
 
 [gh-actions:env]
 DJANGO =
-    2.2: dj22
-    3.1: dj31
-    3.2: dj32
-    4.0: dj40
+    4.2: dj42
+    5.0: dj50
     main: djmain
 
 [testenv]
 deps =
     coverage
-    dj22: Django>=2.2,<3.0
-    dj31: Django>=3.1,<3.2
-    dj32: Django>=3.2,<3.3
-    dj40: Django>=4.0,<4.1
+    dj42: Django>=4.2,<5.0
+    dj50: Django>=5.0,<5.1
     djmain: https://github.com/django/django/archive/main.tar.gz
     pytest
     pytest-cov


### PR DESCRIPTION
Currently, only Django versions 4.2 and 5.0 are maintained and
collectively only support Python down to version 3.8. This change updates the support matrix
for this package to match.